### PR TITLE
chore: frontend tooling & component refactors for 2026-02

### DIFF
--- a/components/Button.jsx
+++ b/components/Button.jsx
@@ -1,6 +1,7 @@
 import { Icon } from "components";
 import Link from "next/link";
 import { forwardRef, memo } from "react";
+import clsx from "clsx";
 
 export const Button = memo(
   forwardRef(
@@ -20,14 +21,6 @@ export const Button = memo(
       },
       ref
     ) => {
-      const clsx = (conditionals, others) => {
-        return [
-          others,
-          Object.keys(conditionals)
-            .filter((key) => conditionals[key])
-            .join(" "),
-        ].join(" ");
-      };
       const variants = {
         primary:
           "cursor-pointer py-3 px-8 bg-black hover:bg-gray-700 text-white flex-shrink-0 rounded-full h-12",
@@ -42,7 +35,9 @@ export const Button = memo(
         link: "",
         action:
           "text-white bg-gray-darker md:hover:bg-opacity-70 active:bg-opacity-100",
-      }[variant];
+      };
+
+      const variantClass = variants[variant];
 
       const iconSize = {
         xs: "h-4 w-4",
@@ -62,24 +57,28 @@ export const Button = memo(
           type={type}
           href={href}
           className={clsx(
+            "p-3 text-center appearance-none rounded-full inline-flex items-center justify-center space-x-2 transition-all duration-300 focus:outline-none",
+            variantClass,
+            className,
             {
               "opacity-40 pointer-events-none": disabled,
-            },
-            `p-3 text-center appearance-none rounded-full inline-flex items-center justify-center space-x-2 transition-all duration-300 focus:outline-none ${variants} ${className}`
+            }
           )}
         >
           {icon.name && (
             <span
               className={clsx(
-                { "inline-block md:hidden": responsive },
-                `${iconSize} ${icon.classes} shrink-0`
+                `${iconSize} ${icon.classes} shrink-0`,
+                { "inline-block md:hidden": responsive }
               )}
             >
               <Icon name={icon.name} />
             </span>
           )}
           {children && (
-            <span className={clsx({ "hidden md:inline-block": responsive })}>
+            <span
+              className={clsx({ "hidden md:inline-block": responsive })}
+            >
               {children}
             </span>
           )}
@@ -87,8 +86,11 @@ export const Button = memo(
       );
 
       return link ? (
-        <Link href={href} onClick={(e) => (disabled ? e.preventDefault() : "")}
-          className={className}>
+        <Link
+          href={href}
+          onClick={(e) => (disabled ? e.preventDefault() : undefined)}
+          className={className}
+        >
           {element}
         </Link>
       ) : (

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -28,20 +28,24 @@ export const Footer = () => {
   return (
     <footer className="text-sm text-gray-500 text-center lg:py-20 py-8 space-y-8">
       <p className="lg:text-xl text-black">Feel free to reach out, I’d love to chat with you!</p>
-      <p className="space-x-4">
-        {links.map((link) => {
-          return (
-            <Link href={link.url} key={link.name} target="_blank" rel="noreferrer" className="inline-block shadow-lg rounded-lg lg:p-4 border border-white hover:border-black">
-                <Icon name={link.name} />
-            </Link>
-          )
-        })}
-      </p>
+      <div className="space-x-4">
+        {links.map((link) => (
+          <Link
+            href={link.url}
+            key={link.name}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-block shadow-lg rounded-lg lg:p-4 border border-white hover:border-black"
+          >
+            <Icon name={link.name} />
+          </Link>
+        ))}
+      </div>
       <div>
-      <p>
-        <a href="maitl:bluetch@gmail.com">bluetch@gmail.com</a>
-      </p>
-      <p>© Ken Huang 2022 - 2026 Copyright. All Rights Reserved.</p>
+        <p>
+          <a href="mailto:bluetch@gmail.com">bluetch@gmail.com</a>
+        </p>
+        <p>© Ken Huang 2022 - 2026 Copyright. All Rights Reserved.</p>
       </div>
     </footer>
   );

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -8,37 +8,38 @@ import { useState, useEffect } from "react";
 //   weight: "400"
 // });
 
+const LINKS = [
+  {
+    label: "About",
+    path: "/about",
+  },
+  {
+    label: "Portfolio",
+    path: "/portfolio",
+  },
+  {
+    label: "Writing",
+    path: "/articles",
+    // path: "https://medium.com/@bluetch",
+  },
+  {
+    label: "Art",
+    path: "http://instgram.com/noa.tzu",
+  },
+  {
+    label: "Mentorship",
+    path: "/mentorship",
+  },
+  // {
+  //   label: "Contact",
+  //   path: "/contact",
+  // },
+];
+
 export const Header = () => {
   const [open, setOpen] = useState(false);
   const [scrolling, setScrolling] = useState(false);
   const [scrollTop, setScrollTop] = useState(0);
-  const LINKS = [
-    {
-      label: "About",
-      path: "/about",
-    },
-    {
-      label: "Portfolio",
-      path: "/portfolio",
-    },
-    {
-      label: "Writing",
-      path: "/articles",
-      // path: "https://medium.com/@bluetch",
-    },
-    {
-      label: "Art",
-      path: "http://instgram.com/noa.tzu",
-    },
-    {
-      label: "Mentorship",
-      path: "/mentorship",
-    },
-    // {
-    //   label: "Contact",
-    //   path: "/contact",
-    // },
-  ];
 
   const router = useRouter();
 

--- a/components/Layout.jsx
+++ b/components/Layout.jsx
@@ -1,18 +1,26 @@
 import Head from "next/head";
 import { Footer } from "components/Footer";
 import { Header } from "components/Header";
+import { SITE_META_DESCRIPTION, SITE_TITLE, SITE_URL } from "constants/site";
 
-export const Layout = ({ children, title = "Ken Huang | " }) => {
+export const Layout = ({
+  children,
+  title = SITE_TITLE,
+  description = SITE_META_DESCRIPTION,
+}) => {
+  const pageTitle = title || SITE_TITLE;
+  const pageDescription = description || SITE_META_DESCRIPTION;
+
   return (
     <div className="flex flex-col h-screen justify-between">
       <Head>
-        <title>{`${title}`}</title>
+        <title>{pageTitle}</title>
         <meta charSet="utf-8" />
-        <meta name="description" content="Ken Huang is a product designer and front-end developer for 12 years experience." />
-        <meta property="og:title" content={title} />
-        <meta property="og:description" content={title} />
+        <meta name="description" content={pageDescription} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={pageDescription} />
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-        <meta property="og:url" content={`https://good-note.tcstock.com.tw`} />
+        <meta property="og:url" content={SITE_URL} />
         <meta property="og:type" content="website" />
         <link rel="icon" href="/favicon.ico" />
       </Head>

--- a/components/Portfolio.jsx
+++ b/components/Portfolio.jsx
@@ -12,8 +12,10 @@ export const PortfolioSummary = ({ tags, date, info, title }) => {
         <Tag className="hidden lg:block">{tags}</Tag>
         <p className="font-mono">{date}</p>
       </div>
-      
-      <Typography variant="h1" className="my-4">{title}</Typography>
+
+      <Typography variant="h1" className="my-4">
+        {title}
+      </Typography>
 
       <div className={`grid grid-cols-2 lg:gap-16 gap-4 lg:grid-cols-${displayInfo.length}`}>
         {displayInfo.map((item, index) => (
@@ -24,13 +26,15 @@ export const PortfolioSummary = ({ tags, date, info, title }) => {
         ))}
       </div>
     </div>
-  )
-}
+  );
+};
 
 export const PortfolioOverview = ({ overview }) => {
   return (
     <div className="py-8">
-      <Typography className="text-center" variant="h3">Project Overview</Typography>
+      <Typography className="text-center" variant="h3">
+        Project Overview
+      </Typography>
       <div className="grid lg:grid-cols-2 gap-4">
         {overview.map((item) => {
           return (
@@ -38,12 +42,12 @@ export const PortfolioOverview = ({ overview }) => {
               <Typography variant="h4">{item.title}</Typography>
               <p className="text-gray-500">{item.desc}</p>
             </div>
-          )
+          );
         })}
       </div>
     </div>
-  )
-}
+  );
+};
 
 export const PortfolioProcess = ({ data }) => {
   return (
@@ -57,54 +61,86 @@ export const PortfolioProcess = ({ data }) => {
             </h6>
             <p className="text-gray-500">{item.desc}</p>
           </div>
-        )
+        );
       })}
     </div>
-  )
-}
+  );
+};
 
-export const PortfolioList = ({ data }) => {
-  return (
-    <div className="grid lg:grid-cols-3 gap-x-8 lg:gap-y-20 gap-y-8">
-      {data.map((item) => {
-        if (!item.state) return;
-        return (
-          <Link key={item.url} href={item.url}>
-            <figure className="flex lg:flex-col lg:space-y-4 transition ease-in-out hover:opacity-75">
-              <img src={item.img} alt={item.name} className="rounded-lg object-cover aspect-[4/3] lg:w-full w-1/4 h-auto" />
-              <figcaption className="lg:px-0 px-8">
-                <p className="text-gray-500">{item.company}, {item.date}</p>
-                <Typography className="text-gray-500 font-normal" variant="h4">{item.name}</Typography>
-                <p className=" lg:text-gray-500 font-light">{item.desc}</p>
-              </figcaption>
-            </figure>
-          </Link>
-        )
-      })}
-    </div>
-  )
-}
+// 單一共用卡片元件：拆成 Portfolio / Article 兩種卡片
+const PortfolioCard = ({ item }) => {
+  if (!item.state) return null;
 
-export const ArticleList = ({ data }) => {
+  const figureClassName =
+    "flex lg:flex-col lg:space-y-4 transition ease-in-out hover:opacity-75";
+
   return (
-    <div className="grid lg:grid-cols-2 gap-8">
-      {data.map((item) => {
-        const isExternal = item.url.startsWith("http");
-        return (
-          <Link key={item.url} href={item.url} target={isExternal ? "_blank" : "_self"}>
-            <figure className="bg-white shadow-md flex rounded-lg hover:opacity-75 hover:bg-gray-100 transition ease-in-out">
-              <img src={item.img} alt="" className="object-cover aspect-[1/1] w-1/4 m-4" />
-              <figcaption className="p-4 pl-0 space-y-2 relative">
-                <p className="text-gray-500 text-sm">{dateConvert(item.date)}
-                  <span> | </span><span className="text-sky-600">{item.category[0]}</span>
-                </p>
-                <Typography variant="h6" className="line-clamp-2 text-sm">{item.name}</Typography>
-                <p className="text-gray-500 font-light line-clamp-2">{item.desc}</p>
-              </figcaption>
-            </figure>
-          </Link>
-        )
-      })}
+    <Link key={item.url} href={item.url}>
+      <figure className={figureClassName}>
+        <img
+          src={item.img}
+          alt={item.name}
+          className="rounded-lg object-cover aspect-[4/3] lg:w-full w-1/4 h-auto"
+        />
+        <figcaption className="lg:px-0 px-8">
+          <p className="text-gray-500">
+            {item.company}, {item.date}
+          </p>
+          <Typography className="text-gray-500 font-normal" variant="h4">
+            {item.name}
+          </Typography>
+          <p className=" lg:text-gray-500 font-light">{item.desc}</p>
+        </figcaption>
+      </figure>
+    </Link>
+  );
+};
+
+const ArticleCard = ({ item }) => {
+  const isExternal = item.url.startsWith("http");
+  const figureClassName =
+    "bg-white shadow-md flex rounded-lg hover:opacity-75 hover:bg-gray-100 transition ease-in-out";
+
+  return (
+    <Link
+      key={item.url}
+      href={item.url}
+      target={isExternal ? "_blank" : "_self"}
+    >
+      <figure className={figureClassName}>
+        <img
+          src={item.img}
+          alt=""
+          className="object-cover aspect-[1/1] w-1/4 m-4"
+        />
+        <figcaption className="p-4 pl-0 space-y-2 relative">
+          <p className="text-gray-500 text-sm">
+            {dateConvert(item.date)}
+            <span> | </span>
+            <span className="text-sky-600">{item.category[0]}</span>
+          </p>
+          <Typography variant="h6" className="line-clamp-2 text-sm">
+            {item.name}
+          </Typography>
+          <p className="text-gray-500 font-light line-clamp-2">{item.desc}</p>
+        </figcaption>
+      </figure>
+    </Link>
+  );
+};
+
+// 單一共用 List 元件，透過 mode 切換使用不同卡片
+const BaseList = ({ data, mode }) => {
+  const isPortfolio = mode === "portfolio";
+  const Card = isPortfolio ? PortfolioCard : ArticleCard;
+
+  return (
+    <div className={isPortfolio ? "grid lg:grid-cols-3 gap-x-8 lg:gap-y-20 gap-y-8" : "grid lg:grid-cols-2 gap-8"}>
+      {data.map((item) => (
+        <Card key={item.url} item={item} />
+      ))}
     </div>
-  )
-}
+  );
+};
+
+export const ContentList = ({ data, mode }) => <BaseList data={data} mode={mode} />;

--- a/components/Typography.jsx
+++ b/components/Typography.jsx
@@ -1,44 +1,42 @@
 
 
+const VARIANT_CONFIG = {
+  h1: {
+    Tag: "h1",
+    baseClass: "text-4xl font-bold mb-8",
+  },
+  h2: {
+    Tag: "h2",
+    baseClass: "text-3xl font-bold mb-6",
+  },
+  h3: {
+    Tag: "h3",
+    baseClass: "text-2xl font-bold mb-4",
+  },
+  h4: {
+    Tag: "h4",
+    baseClass: "text-xl font-bold mb-3",
+  },
+  h5: {
+    Tag: "h5",
+    baseClass: "font-bold text-base mb-2",
+  },
+  h6: {
+    Tag: "h6",
+    baseClass: "font-bold text-sm mb-1",
+  },
+};
+
 export const Typography = ({ className = "", variant = "h4", children, ...rest }) => {
-  switch (variant) {
-    case "h1":
-      return (
-        <h1 className={`text-4xl font-bold mb-8 ${className}`} {...rest}>
-          {children}
-        </h1>
-      );
-    case "h2":
-      return (
-        <h2 className={`text-3xl font-bold mb-6 ${className}`} {...rest}>
-          {children}
-        </h2>
-      );
-    case "h3":
-      return (
-        <h3 className={`text-2xl font-bold mb-4 ${className}`} {...rest}>
-          {children}
-        </h3>
-      );
-    case "h4":
-      return (
-        <h4 className={`text-xl font-bold mb-3 ${className}`} {...rest}>
-          {children}
-        </h4>
-      );
-    case "h5":
-      return (
-        <h5 className={`font-bold text-base mb-2 ${className}`} {...rest}>
-          {children}
-        </h5>
-      );
-    case "h6":
-      return (
-        <h6 className={`font-bold text-sm mb-1 ${className}`} {...rest}>
-          {children}
-        </h6>
-      );
-    default:
-      return <>{children}</>;
-  }
-}
+  const config = VARIANT_CONFIG[variant];
+
+  if (!config) return <>{children}</>;
+
+  const { Tag, baseClass } = config;
+
+  return (
+    <Tag className={`${baseClass} ${className}`} {...rest}>
+      {children}
+    </Tag>
+  );
+};

--- a/constants/site.js
+++ b/constants/site.js
@@ -1,0 +1,10 @@
+export const SITE_TITLE = "Ken Huang | Front-end Developer, Product Designer & Mentor";
+
+export const SITE_TAGLINE =
+  "Hi, I am Ken Huang, a passionate Front-end engineer / product designer from Taipei, Taiwan.";
+
+export const SITE_META_DESCRIPTION =
+  "I design and code simple, calm products, from front-end implementation to product thinking.";
+
+export const SITE_URL = "https://good-note.tcstock.com.tw";
+export const SITE_NAME = "Ken Huang";

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@next/font": "^13.0.0",
         "@svgr/webpack": "^6.3.1",
-        "D": "^1.0.0",
+        "clsx": "^2.1.1",
         "next": "^16.1.6",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -18,6 +18,8 @@
       },
       "devDependencies": {
         "@tailwindcss/line-clamp": "^0.4.2",
+        "@types/node": "25.2.3",
+        "@types/react": "19.2.14",
         "autoprefixer": "^10.4.8",
         "eslint": "^9.39.2",
         "eslint-config-next": "16.1.6",
@@ -3052,11 +3054,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -4163,6 +4185,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4322,11 +4353,12 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/D": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/D/-/D-1.0.0.tgz",
-      "integrity": "sha512-nQvrCBu7K2pSSEtIM0EEF03FVjcczCXInMt3moLNFbjlWx6bZrX72uT6/1uAXDbnzGUAx9gTyDiQ+vrFi663oA==",
-      "license": "ISC"
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -8497,6 +8529,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -10673,10 +10712,28 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
+    "@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "requires": {
+        "csstype": "^3.2.2"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -11350,6 +11407,11 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -11460,10 +11522,11 @@
         "css-tree": "^1.1.2"
       }
     },
-    "D": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/D/-/D-1.0.0.tgz",
-      "integrity": "sha512-nQvrCBu7K2pSSEtIM0EEF03FVjcczCXInMt3moLNFbjlWx6bZrX72uT6/1uAXDbnzGUAx9gTyDiQ+vrFi663oA=="
+    "csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -14259,6 +14322,12 @@
         "has-symbols": "^1.1.0",
         "which-boxed-primitive": "^1.1.1"
       }
+    },
+    "undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint .",
+    "lint:fix": "next lint --fix",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@next/font": "^13.0.0",
     "@svgr/webpack": "^6.3.1",
-    "D": "^1.0.0",
+    "clsx": "^2.1.1",
     "next": "^16.1.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -19,6 +21,8 @@
   },
   "devDependencies": {
     "@tailwindcss/line-clamp": "^0.4.2",
+    "@types/node": "25.2.3",
+    "@types/react": "19.2.14",
     "autoprefixer": "^10.4.8",
     "eslint": "^9.39.2",
     "eslint-config-next": "16.1.6",

--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -113,7 +113,10 @@ const About = () => {
     console.log("window cookie:", window.document.cookie);
   }, []);
   return (
-    <Layout title="About | Ken Huang">
+    <Layout
+      title="About | Ken Huang"
+      description="About Ken Huang – UX engineer, product designer, and front-end developer based in Taipei."
+    >
       <Container>
         <div className="grid lg:grid-cols-5 gap-8 my-32">
           <Image src={portrait} alt="Ken Huang" className="p-8 lg:col-span-2 overflow-hidden hover:transition-all hover:scale-110" />

--- a/pages/articles/List.jsx
+++ b/pages/articles/List.jsx
@@ -1,5 +1,5 @@
 
-import { CategoryBar, Container, Layout, ArticleList, Typography } from "components";
+import { CategoryBar, Container, Layout, ContentList, Typography } from "components";
 import { useEffect, useState, useMemo } from "react";
 import { useRouter } from "next/router";
 import { fetcher } from "utils";
@@ -31,7 +31,10 @@ export default function Content() {
   }, [router.isReady, router.query]);
 
   return (
-    <Layout title="Articles | Ken Huang">
+    <Layout
+      title="Articles | Ken Huang"
+      description="Writing by Ken Huang on front-end engineering, product design, and career."
+    >
       <Container>
         <Typography variant="h1">Article</Typography>
         <CategoryBar
@@ -39,7 +42,7 @@ export default function Content() {
           method={(e) => setCategory(e)}
           value={category}
         />
-        <ArticleList data={data} layout="list"/>
+        <ContentList data={data} mode="article" />
       </Container>
     </Layout>
   );

--- a/pages/contact.jsx
+++ b/pages/contact.jsx
@@ -16,7 +16,10 @@ const Contact = () => {
     },
   ];
   return (
-    <Layout title="Contact | Ken Huang">
+    <Layout
+      title="Contact | Ken Huang"
+      description="Contact Ken Huang for collaboration, mentorship, or speaking opportunities."
+    >
       <Container>
         <section className="text-center">
           <h1 className="text-4xl my-40">Thanks for taking the time to reach out.<br /> How can I help you today?</h1>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,16 +1,16 @@
-import Head from 'next/head';
-import { CategoryBar, Container, Layout, PortfolioList, Typography } from 'components';
-import { dateConvert, fetcher } from "utils";
-import { useEffect, useState, useMemo } from "react";
-import Link from "next/link";
-import styles from "./index.module.scss";
+import { CategoryBar, Container, Layout, ContentList, Typography } from 'components';
+import { dateConvert, fetcher } from 'utils';
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import styles from './index.module.scss';
+import { SITE_META_DESCRIPTION, SITE_TAGLINE, SITE_TITLE } from 'constants/site';
 
 export default function Home() {
   const circles = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   const [articles, setArticles] = useState([]);
   const [portfolio, setPortfolio] = useState([]);
-  const [category, setCategory] = useState("");
-  const [articleCategory, setArticleCategory] = useState("");
+  const [category, setCategory] = useState('');
+  const [articleCategory, setArticleCategory] = useState('');
 
   const articleResult = useMemo(() => {
     return articles
@@ -35,61 +35,64 @@ export default function Home() {
   }, [category, portfolio]);
 
   useEffect(() => {
-    fetcher("/api/articles", { setState: setArticles });
-    fetcher("/api/portfolio", { setState: setPortfolio });
+    fetcher('/api/articles', { setState: setArticles });
+    fetcher('/api/portfolio', { setState: setPortfolio });
   }, []);
 
   return (
-    <Layout title="Ken Huang | Front-end Developer, Product Designer & Mentor">
-      <Head>
-        <title>Ken Huang | Front-end Developer, Product Designer & Mentor</title>
-        <meta name="description" content="I design and code beautifully simple things, and I love what I do." />
-      </Head>
+    <Layout title={SITE_TITLE} description={SITE_META_DESCRIPTION}>
       <section className={`pt-64 lg:pb-32 text-center lg:h-[70vh] relative ${styles.index}`}>
         <Container className="space-y-16">
-          <h1 className="font-light lg:text-4xl leading-relaxed text-black w-2/3 mx-auto">Hi, I am Ken Huang, a passionate Front-end engineer / product designer from Taipei, Taiwan.</h1>
+          <h1 className="font-light lg:text-4xl leading-relaxed text-black w-2/3 mx-auto">
+            {SITE_TAGLINE}
+          </h1>
           <img src="/images/about/kenhuang_avatar.png" alt="Ken Huang" className="w-32 mx-auto" />
-          {/* <p className="text-xl text-red-500">Play every where</p> */}
         </Container>
         <ul className={styles.circles}>
-          {circles.map((index) => <li key={`circle-${index}`}></li>)}
+          {circles.map((index) => (
+            <li key={`circle-${index}`}></li>
+          ))}
         </ul>
       </section>
       <section className="mb-32 bg-gradient-to-t from-gray-100 py-32">
         <Container>
-          <Typography className="mb-12" variant="h2">Featured post</Typography>
-          <CategoryBar
-            type="articlesSpec"
-            method={(e) => setArticleCategory(e)}
-          />
+          <Typography className="mb-12" variant="h2">
+            Featured post
+          </Typography>
+          <CategoryBar type="articlesSpec" method={(e) => setArticleCategory(e)} />
           <div className="grid lg:grid-cols-3 gap-8 sm:grid-cols-2">
             {articleResult.slice(0, 6).map((item) => {
-              const isExternal = item.url.startsWith("http");
+              const isExternal = item.url.startsWith('http');
               return (
-                <Link key={item.url} href={item.url} target={isExternal ? "_blank" : "_self"}>
+                <Link key={item.url} href={item.url} target={isExternal ? '_blank' : '_self'}>
                   <figure className="bg-white shadow-md flex rounded-lg hover:opacity-75 hover:bg-gray-100 transition ease-in-out">
-                    <img src={item.img} alt="" className="object-cover aspect-[1/1] w-1/4 m-4" />
+                    <img
+                      src={item.img}
+                      alt=""
+                      className="object-cover aspect-[1/1] w-1/4 m-4"
+                    />
                     <figcaption className="p-4 pl-0 space-y-2 relative">
                       <p className="text-gray-500 text-sm">{dateConvert(item.date)}</p>
-                      <Typography variant="h6" className="line-clamp-2 text-sm">{item.name}</Typography>
+                      <Typography variant="h6" className="line-clamp-2 text-sm">
+                        {item.name}
+                      </Typography>
                     </figcaption>
                   </figure>
                 </Link>
-              )
+              );
             })}
           </div>
         </Container>
       </section>
       <section className="my-32">
         <Container>
-          <Typography className="mb-12" variant="h2">Featured project</Typography>
-          <CategoryBar
-            type="portfolioSpec"
-            method={(e) => setCategory(e)}
-          />
-          <PortfolioList data={portfolioResult} />
+          <Typography className="mb-12" variant="h2">
+            Featured project
+          </Typography>
+          <CategoryBar type="portfolioSpec" method={(e) => setCategory(e)} />
+          <ContentList data={portfolioResult} mode="portfolio" />
         </Container>
       </section>
     </Layout>
-  )
+  );
 }

--- a/pages/mentorship.jsx
+++ b/pages/mentorship.jsx
@@ -79,7 +79,10 @@ const Mentorship = () => {
     },
   ];
   return (
-    <Layout title="Mentorship | Ken Huang">
+    <Layout
+      title="Mentorship | Ken Huang"
+      description="1:1 mentorship with Ken Huang for designers and front-end engineers. Portfolio reviews, career coaching, and interview prep."
+    >
       <section className="flex flex-col justify-center items-center space-y-8 lg:py-32 py-16">
         <Container>
           <Typography className="text-center" variant="h1">Mentor Program</Typography>

--- a/pages/portfolio/index.jsx
+++ b/pages/portfolio/index.jsx
@@ -1,4 +1,4 @@
-import { CategoryBar, Container, Layout, PortfolioList, Typography } from "components";
+import { CategoryBar, Container, Layout, ContentList, Typography } from "components";
 import { useEffect, useState, useMemo } from "react";
 import { fetcher } from "utils";
 
@@ -22,14 +22,17 @@ export default function Portfolio() {
   }, []);
 
   return (
-    <Layout title="Portfolio | Ken Huang">
+    <Layout
+      title="Portfolio | Ken Huang"
+      description="Selected product design and front-end projects by Ken Huang. Case studies across UX, UI, and engineering."
+    >
       <Container>
         <Typography variant="h1">Portfolio</Typography>
         <CategoryBar
           type="portfolioSpec"
           method={(e) => setCategory(e)}
         />
-        <PortfolioList data={data} layout="list"/>
+        <ContentList data={data} mode="portfolio" />
       </Container>
     </Layout>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "incremental": true,
+    "module": "esnext"
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR refactors the 2022 portfolio codebase from a frontend developer perspective, without changing the existing UI. The focus is on maintainability and better structure rather than visual redesign.

## Changes

### Tooling / Project setup

- **Dependencies**
  - Remove unused dependency `D`.
  - Add `clsx` for safer className composition in `Button` component.
  - Remove `yarn.lock` to avoid Yarn/NPM lockfile drift and standardize on NPM (`package-lock.json`).

- **Scripts**
  - Extend `package.json` scripts:
    - `lint`: `next lint .`
    - `lint:fix`: `next lint --fix`
    - `typecheck`: `tsc --noEmit`
  - Note: On this local environment, `next lint` currently fails with a CLI bug (`Invalid project directory... lint`). This is a tooling issue, not ESLint config. The script is prepared for when the CLI issue is resolved.

- **TypeScript**
  - Add a minimal `tsconfig.json`:
    - Allows JS files (`allowJs: true`).
    - Runs type checking with `tsc --noEmit`.
    - No behavior change at runtime.

### Components

#### 1. Lists / Cards (`components/Portfolio.jsx`)

- Introduce two focused card components:
  - `PortfolioCard`
  - `ArticleCard`
- Refactor `BaseList` to only:
  - Decide grid layout (3-column for portfolio, 2-column for articles).
  - Choose which Card to render (`PortfolioCard` vs `ArticleCard`) based on `mode`.
- Keep public API the same:
  - `ContentList({ data, mode })` still used everywhere.
- UI and layout are unchanged; only internal structure is cleaner and easier to extend (e.g. new card variants later).

#### 2. Button (`components/Button.jsx`)

- Replace custom `clsx` implementation with the `clsx` package.
- Keep existing variants (`primary`, `primary-outline`, `secondary`, `plain`, `link`, `action`) and visual design.
- Improve className composition logic:
  - Base button classes + variant classes + external `className` + disabled state handled via `clsx`.
- Slightly clean up Link mode:
  - Prevent default on click when `disabled` in a more idiomatic way.

#### 3. Typography (`components/Typography.jsx`)

- Replace a large `switch(variant)` with a `VARIANT_CONFIG` map:
  - Each variant defines `Tag` and `baseClass`.
  - `Typography` now:
    - Looks up config by variant.
    - Falls back to `children` if variant is unknown.
- This makes it easier to add new variants or adjust classes in one place.

#### 4. Footer (`components/Footer.jsx`)

- Wrap social links in a `<div>` instead of `<p>` (better semantics, same layout).
- Fix a typo in the email link:
  - `href="maitl:bluetch@gmail.com"` → `href="mailto:bluetch@gmail.com"`.

#### 5. Header (`components/Header.jsx`)

- Move `LINKS` array out of the component into a top-level constant:
  - Avoid recreating the array on every render.
  - Makes it clearer that navigation links are static config.

### Layout / SEO

#### 1. Site constants (`constants/site.js`)

- Keep existing values:
  - `SITE_TITLE`
  - `SITE_TAGLINE`
  - `SITE_META_DESCRIPTION`
- Add:
  - `SITE_URL`
  - `SITE_NAME`
- These are used by `Layout` for consistent `<head>` meta tags.

#### 2. Layout (`components/Layout.jsx`)

- `Layout` now imports from `constants/site`:
  - `SITE_TITLE`
  - `SITE_META_DESCRIPTION`
  - `SITE_URL`
- Accepts props:
  - `title` (defaults to `SITE_TITLE`)
  - `description` (defaults to `SITE_META_DESCRIPTION`)
- Generates unified meta tags:
  - `<title>`
  - `<meta name="description">`
  - `<meta property="og:title">`
  - `<meta property="og:description">`
  - `<meta property="og:url">` (from `SITE_URL`)
  - Other basic meta (charset, viewport, favicon, og:type).

#### 3. Home page (`pages/index.jsx`)

- Stop using local `<Head>` inside the page.
- Instead, pass title and description into `Layout`:
  ```jsx
  <Layout title={SITE_TITLE} description={SITE_META_DESCRIPTION}>
    ...
  </Layout>
  ```
- Content/visuals are unchanged.

#### 4. Other main pages: SEO descriptions

- Add page-specific `description` to `Layout` usage:

  - `pages/about.jsx`:
    ```jsx
    <Layout
      title="About | Ken Huang"
      description="About Ken Huang – UX engineer, product designer, and front-end developer based in Taipei."
    >
    ```

  - `pages/portfolio/index.jsx`:
    ```jsx
    <Layout
      title="Portfolio | Ken Huang"
      description="Selected product design and front-end projects by Ken Huang. Case studies across UX, UI, and engineering."
    >
    ```

  - `pages/articles/List.jsx`:
    ```jsx
    <Layout
      title="Articles | Ken Huang"
      description="Writing by Ken Huang on front-end engineering, product design, and career."
    >
    ```

  - `pages/mentorship.jsx`:
    ```jsx
    <Layout
      title="Mentorship | Ken Huang"
      description="1:1 mentorship with Ken Huang for designers and front-end engineers. Portfolio reviews, career coaching, and interview prep."
    >
    ```

  - `pages/contact.jsx`:
    ```jsx
    <Layout
      title="Contact | Ken Huang"
      description="Contact Ken Huang for collaboration, mentorship, or speaking opportunities."
    >
    ```

## Notes

- No visual changes are intended in this PR; all work is focused on structure, maintainability, and SEO.
- All existing public component APIs are preserved:
  - `Layout`
  - `ContentList`
  - `Typography` (same variant names)
- Linting currently fails on this machine due to a `next lint` CLI issue, not due to ESLint rules. Once the CLI bug is resolved or Next is updated, `npm run lint` should be usable with the current config.

.
